### PR TITLE
feat: allow username and api key to be given via command line argument

### DIFF
--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -11,6 +11,7 @@ on:
     branches: ['main']
     paths-ignore:
       - '**.md'
+      - '**.png'
       - '.gitignore'
   workflow_dispatch:
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,7 +28,7 @@ dependencies = [
 
 [[package]]
 name = "anijouhou"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "chrono",
  "open",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "anijouhou"
 description = "Terminal application that displays the total amount of time spent watching anime by fetching data from anilist."
-version = "0.2.1"
+version = "0.3.0"
 edition = "2024"
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Simply add the following to your `~/.config/fastfetch/config.jsonc`
 ```
 ## Switch between accounts
 `anijouhou` does not directly provide a way to switch between anilist accounts. However you can write a shell script like the one below to get this functionality. <br>
-See [here](scripts/README.md) for additional information on the script below.
+See [here](scripts/) for additional information on the script below.
 ```bash
 #!/bin/bash
 # In this example user1 requires an api-key, while user2 does not.
@@ -68,3 +68,6 @@ else
   anijouhou -u "$1" -k skip
 fi
 ```
+## Use anijouhou on Android via Termux
+You will need to install the `openssl` package via `pkg install openssl`. <br>
+Other than that you can follow the instructions found in [Build from source](#build-from-source).

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ Terminal application written in Rust that displays the total amount of time spen
 ## Supplying user data via command line arguments
 - Give username via command line argument: `anijouhou -u <your-username>` or `anijouhou --username <your-username>`
 - Give api-key via command line argument: `anijouhou -k <api-key>` or `anijouhou --api-key <api-key>`
+>[!Tip]
+> If you give `skip` as the api-key, none will be used.
 
 # Installation
 Download the latest release from the [release page](https://github.com/legendofmaj/anijouhou/releases) <br>

--- a/README.md
+++ b/README.md
@@ -4,15 +4,20 @@ Terminal application written in Rust that displays the total amount of time spen
 # Screenshots
 | [anijouhou](https://github.com/legendofmaj/anijouhou/releases) | [anijouhou with fastfetch](https://github.com/fastfetch-cli/fastfetch) |
 | :-----------------------------------------------------------:  | :--------------------------------------------------------------------: |
-| <img src="res/anijouhou.png" width="400"/>                     | <img src="res/fastfetch_anijouhou.png" width="400"/>                   |
+| <img src="res/anijouhou.png" width="500"/>                     | <img src="res/fastfetch_anijouhou.png" width="500"/>                   |
 
 # Usage
 - Basic usage: `anijouhou`
-- Clear cache(automically cleared daily): `anijouhou -c` or `anijouhou --clear-cache`
-- Delete user data directory(`$HOME/.config/anijouhou`): `anijouhou -d` or `anijouhou --delete`
+## File management
+- Clear cache (automically cleared daily): `anijouhou -c` or `anijouhou --clear-cache`
+- Delete user data directory (`$HOME/.config/anijouhou`): `anijouhou -d` or `anijouhou --delete`
+## Output formatting
 - Get only total watchtime hours: `anijouhou -h` or `anijouhou --hours`
 - Get only total watchtime in minutes: `anijouhou -m` or `anijouhou --minutes`
 - Get only total amount of episodes watched: `anijouhou -e` or `anijouhou --episodes`
+## Supplying user data via command line arguments
+- Give username via command line argument: `anijouhou -u <your-username>` or `anijouhou --username <your-username>`
+- Give api-key via command line argument: `anijouhou -k <api-key>` or `anijouhou --api-key <api-key>`
 
 # Installation
 Download the latest release from the [release page](https://github.com/legendofmaj/anijouhou/releases) <br>
@@ -43,4 +48,21 @@ Simply add the following to your `~/.config/fastfetch/config.jsonc`
   "type": "command",
   "text": "anijouhou -h" // or any other flag you want
 }
+```
+## Switch between accounts
+`anijouhou` does not directly provide a way to switch between anilist accounts. However you can write a shell script like the one below to get this functionality. <br>
+See [here](scripts/README.md) for additional information on the script below.
+```bash
+#!/bin/bash
+# In this example user1 requires an api-key, while user2 does not.
+username1="your_username"
+api_key_user1="your_api_key"
+
+anijouhou -d
+if [[ $1 == "$username1" ]];
+then
+  anijouhou -u "$1" -k $api_key_user1
+else
+  anijouhou -u "$1" -k skip
+fi
 ```

--- a/README.md
+++ b/README.md
@@ -69,5 +69,6 @@ else
 fi
 ```
 ## Use anijouhou on Android via Termux
-You will need to install the `openssl` package via `pkg install openssl`. <br>
-Other than that you can follow the instructions found in [Build from source](#build-from-source).
+- Install the `openssl` package via `pkg install openssl`
+- Follow the instructions in [Build from source](#build-from-source) to build an executable
+- Move the executable to your binary directory `mv /data/data/com.termux/files/usr/bin/`

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,9 @@
+# About
+A simple shell script for anijouhou to switch between accounts.
+# Configuration
+This shell script allows the configuration of one user that has set their profile to private. Simply fill the variables with your data. <br> Should you have more than one user that has set their profile to private, add new variables and an additional `else if` condition.
+# Usage
+`aniaccount.sh username`
+# Installation
+- make the script executable `chmod +x aniaccount.sh`
+- move the script to your binary directory for `mv aniaccount.sh /usr/bin/`

--- a/scripts/aniaccount.sh
+++ b/scripts/aniaccount.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# In this example user1 requires an api-key, while user2 does not.
+username1="your_username"
+api_key_user1="your_api_key"
+
+anijouhou -d
+if [[ $1 == "$username1" ]];
+then
+  anijouhou -u "$1" -k $api_key_user1
+else
+  anijouhou -u "$1" -k skip
+fi

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,6 +20,8 @@ fn main()
   }
 
   let mut verbosity: Verbosity = Verbosity::All;
+  let mut username: String  = "none".to_string();
+  // let mut api_key: String = "none".to_string();
 
   // Check for command line arguments
   let args: Vec<String> = std::env::args().collect();
@@ -49,7 +51,20 @@ fn main()
     {
       verbosity = Verbosity::Minutes;
     }
+    else if args[i] == "-u" || args[i] == "--username"
+    {
+      username = args[i+1].clone();
+    }
+    // else if args[i] == "-k" || args[i] == "--api-key"
+    // {
+    //   // You can write anijouhou -k skip
+    //   if args[i+1] != "skip" || args[i+1] != "none"
+    //   {api_key = args[i+1].clone();}
+    //   else {println!("skipping");} //ToDo: Remove
+    // }
   }
+
+  // println!("api key is {}", api_key);
 
   // get api response
   let api_response: serde_json::Value;
@@ -59,7 +74,7 @@ fn main()
     let file_size = std::fs::metadata(cache_file.clone()).unwrap().len();
     if file_size == 0 // check if file is empty
     {
-      api_response = save_user_information(user_data_folder, user_data_path, cache_file);
+      api_response = save_user_information(user_data_folder, user_data_path, cache_file, username);
     }
     else 
     {
@@ -68,7 +83,7 @@ fn main()
   }
   else 
   {
-    api_response = save_user_information(user_data_folder, user_data_path, cache_file);
+    api_response = save_user_information(user_data_folder, user_data_path, cache_file, username);
   }
 
   // parse json
@@ -100,10 +115,10 @@ fn main()
   
 }
 
-fn save_user_information(user_data_folder: String, user_data_path: String, cache_file: String) -> serde_json::Value
+fn save_user_information(user_data_folder: String, user_data_path: String, cache_file: String, username: String) -> serde_json::Value
 {
   // ask user for api_key
-  let data: Vec<String> = get_api_key(user_data_folder.clone(), user_data_path);
+  let data: Vec<String> = get_api_key(user_data_folder.clone(), user_data_path, username);
   // send request and save result
   let api_response = request(data[0].clone(), data[1].clone());
   // check if the api response contains errors.
@@ -121,7 +136,7 @@ fn save_user_information(user_data_folder: String, user_data_path: String, cache
   return api_response;
 }
 
-fn get_api_key(user_data_folder: String, user_data_path: String) -> Vec<String>
+fn get_api_key(user_data_folder: String, user_data_path: String, mut username: String) -> Vec<String>
 {
   // create folder if it doesn't exists
   if std::path::Path::new(&user_data_folder).exists() == false
@@ -130,7 +145,7 @@ fn get_api_key(user_data_folder: String, user_data_path: String) -> Vec<String>
   }
 
   // declare variables
-  let username: String;
+  //let username: String;
   let access_token: String;
 
   // Check for exisiting user-data
@@ -143,10 +158,12 @@ fn get_api_key(user_data_folder: String, user_data_path: String) -> Vec<String>
   }
   else 
   {
-    // ask the user for their username
-    println!("Please enter your username.");
-    username = read!();
-
+    // Ask the user for their username
+    if username == "none"
+    {
+      println!("Please enter your username.");
+      username = read!();
+    }
     // Ask the user if they want to log in
     println!("Do you want to log in?[y|n]");
     println!("If your account is set to private this is required.");
@@ -155,7 +172,7 @@ fn get_api_key(user_data_folder: String, user_data_path: String) -> Vec<String>
     {
       // If they do open a browser window with the login url
       open::that("https://anilist.co/api/v2/oauth/authorize?client_id=30455&response_type=token").expect("Should open Browser Window.");
-      // Let them enter the data
+      // Let them enter their data
       println!("Please enter your access token");
       access_token = read!();
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -121,7 +121,7 @@ fn save_user_information(user_data_folder: String, user_data_path: String, cache
   {
     println!("The data for this user is not available publicly. Have your set your anilist account to private?");
     println!("Is {} the correct spelling of your username?", data[0]);
-    print!("Userdata will not be saved.");
+    print!("User data will not be saved.");
     // User data should not be saved.
     std::fs::remove_dir_all(user_data_folder).expect("anijouhou config directory cannot be deleted.");
     std::process::exit(404);
@@ -150,8 +150,6 @@ fn get_api_key(user_data_folder: String, user_data_path: String, mut username: S
   else 
   {
     // Ask the user for their username
-    // This is a bit confusing naming. In this case "none" means it is not yet defined, while "skip" it should not be set.
-    // However the if condition behind "none" then gives the api_key a value, while "skip" changes it to none.
     if username == "none"
     {
       println!("Please enter your username.");
@@ -176,15 +174,11 @@ fn get_api_key(user_data_folder: String, user_data_path: String, mut username: S
         api_key = "skip".to_string();
       }
     }
-    // else if api_key == "skip"
-    // {
-    //   api_key = "none".to_string();
-    // }
 
     let final_output: String = username.clone() + "\n" + &api_key;
     std::fs::write(&user_data_path, final_output).expect("Should write to config file.");
   }
-  let data = vec![username, api_key]; //ToDo: This "clone" can probably be removed.
+  let data = vec![username, api_key];
   return data;
 }
 
@@ -243,7 +237,6 @@ async fn request(username: String, access_token: String) -> serde_json::Value {
 
 fn write_cache(result: String, cache_file: String)
 {
-  // --write cache--
   // write current data to cache
   let today = Local::now().date_naive().to_string();
   // write result to file


### PR DESCRIPTION
# What's changed

- New `-u` / `--username` flag to give username via command line argument
- New `-k` / `--api-key` flag to give api-key via command line argument
- Optional shell script to switch between anilist accounts
- Make pictures in README bigger